### PR TITLE
Allow building with perl 5.22

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -147,10 +147,9 @@ sub MY::install {
   my $self = shift;
   my $inherited = $self->SUPER::install(@_);
 
-  my $man5 = q{ \\
-		$(INST_MAN5DIR) $(INSTALLMAN5DIR)};
+  $inherited =~ s{(\$\((?:DEST)?INSTALL\w*MAN1DIR\)("?))}{$1 \\
+		$2\$(INST_MAN5DIR)$2 $2\$(INSTALLMAN5DIR)$2}gm;
 
-  $inherited =~ s/(\$\((?:DEST)?INSTALL\w*MAN1DIR\))/$1$man5/gm;
 
   return $inherited;
 }


### PR DESCRIPTION
This patch allows building with perl 5.22.
It also works with older versions.
