### PR TITLE
config: add logtype of 'none' to discard all logging

### DIFF
--- a/lib/Razor2/Client/Agent.pm
+++ b/lib/Razor2/Client/Agent.pm
@@ -126,6 +126,8 @@ sub do_conf {
         $logto = 'syslog';
     } elsif ($self->{conf}->{logfile} eq 'sys-syslog') {
         $logto = 'sys-syslog';
+    } elsif ($self->{conf}->{logfile} eq 'none') {
+        $logto = 'none';
     } else {
         $logto = "file:$self->{conf}->{logfile}";
     }

--- a/lib/Razor2/Client/Config.pm
+++ b/lib/Razor2/Client/Config.pm
@@ -101,7 +101,7 @@ sub read_conf {
                  listfile_discovery whitelist identity)) {
         next unless $conf->{$_};
         next if $conf->{$_} =~ /^\//;
-        next if ($_ eq 'logfile' && ($conf->{$_} eq 'syslog' || $conf->{$_} eq 'sys-syslog'));
+        next if ($_ eq 'logfile' && ($conf->{$_} eq 'syslog' || $conf->{$_} eq 'sys-syslog' || $conf->{$_} eq 'none'));
         $conf->{$_} = "$self->{razorhome}/$conf->{$_}";
     }
     }

--- a/lib/Razor2/Logger.pm
+++ b/lib/Razor2/Logger.pm
@@ -41,6 +41,13 @@ sub new {
         };
         LOGF->autoflush(1);
         $self->{fd} = *LOGF{IO};
+    } elsif ($self->{LogTo} eq 'none') {
+        $self->{LogType} = 'null';
+        open (LOGF, '>>/dev/null') or do {
+            die $!;
+        }
+        LOGF->autoflush(1);
+        $self->{fd} = *LOGF{IO};
     } elsif ($self->{LogTo} eq 'sys-syslog') { 
         # 2003/09/10 Anne Bennett: syslog of our choice (uses socket,
         # does not assume network listener).


### PR DESCRIPTION
Certain distros (like Fedora) discard `Razor2::Agent::Client` logging in
a round-about way (like creating a file which is a symlink to `/dev/null`)
but this might create SElinux issues in turn.

Provide a more direct way to discard logging which isn't vulnerable
to bizarre SElinux AVC's when walking paths to symlinks which just
point to `/dev/null`.

Signed-off-by: Philip Prindeville <philipp@cpan.org>