### PR TITLE
Remove 'use lib' usage

### DIFF
--- a/bin/razor-admin
+++ b/bin/razor-admin
@@ -10,7 +10,7 @@
 ##
 ## $Id: razor-admin,v 1.1 2005/06/16 19:45:54 rsoderberg Exp $
 
-use lib qw(lib);
+
 use strict;
 use Razor2::Client::Agent;
 

--- a/bin/razor-check
+++ b/bin/razor-check
@@ -10,7 +10,7 @@
 ##
 ## $Id: razor-check,v 1.1 2005/06/16 19:45:54 rsoderberg Exp $
 
-use lib qw(lib);
+
 use strict;
 use Razor2::Client::Agent;
 

--- a/bin/razor-report
+++ b/bin/razor-report
@@ -10,7 +10,7 @@
 ##
 ## $Id: razor-report,v 1.1 2005/06/16 19:45:54 rsoderberg Exp $
 
-use lib qw(lib);
+
 use strict;
 use Razor2::Client::Agent;
 

--- a/bin/razor-revoke
+++ b/bin/razor-revoke
@@ -10,7 +10,7 @@
 ##
 ## $Id: razor-revoke,v 1.1 2005/06/16 19:45:54 rsoderberg Exp $
 
-use lib qw(lib);
+
 use strict;
 use Razor2::Client::Agent;
 

--- a/lib/Razor2/Client/Agent.pm
+++ b/lib/Razor2/Client/Agent.pm
@@ -10,7 +10,7 @@
 
 package Razor2::Client::Agent;
 
-use lib qw(lib);
+
 use strict;
 use Getopt::Long;
 use IO::File;


### PR DESCRIPTION
Resolves #5

Shipped scripts should load Perl modules
from the standard location and do not attempt
to load modules from unknown locations.