### PR TITLE
Unbreak builds with parallel make at manifypods-razor

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -131,7 +131,8 @@ MAKE_FRAG
 # begin razor-agents
 %s
 
-manifypods-razor : docs/razor-agent.conf.pod \
+manifypods-razor : config \
+	docs/razor-agent.conf.pod \
 	docs/razor-agents.pod                \
 	docs/razor-whitelist.pod
 	$(POD2MAN) \


### PR DESCRIPTION
The `manifypods-razor` target depends on `INST_MAN5DIR` which gets created by the `config` target. Without this, there may problems building with parallel make. See also:

 - https://sourceforge.net/p/razor/bugs/67/
 - https://bugzilla.redhat.com/show_bug.cgi?id=1379566

Original author: Klaus Heinz (https://sourceforge.net/u/kheinz/)

---

A recent example build failure from Fedora Rawhide:

```
Mock Version: 2.12
Mock Version: 2.12
Mock Version: 2.12
ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -bs --target s390x --nodeps /builddir/build/SPECS/perl-Razor-Agent.spec'], chrootPath='/var/lib/mock/f36-build-31602341-4325681/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0x3ffaaf761f0>timeout=201600uid=1000gid=425user='mockbuild'nspawn_args=[]unshare_net=TrueprintOutput=False)
Executing command: ['bash', '--login', '-c', '/usr/bin/rpmbuild -bs --target s390x --nodeps /builddir/build/SPECS/perl-Razor-Agent.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'} and shell False
sh: line 1: /usr/bin/perl: No such file or directory
Building target platforms: s390x
Building for target s390x
setting SOURCE_DATE_EPOCH=1638835200
Wrote: /builddir/build/SRPMS/perl-Razor-Agent-2.86-1.fc36.src.rpm
Child return code was: 0
ENTER ['do_with_status'](['bash', '--login', '-c', '/usr/bin/rpmbuild -bb --target s390x --nodeps /builddir/build/SPECS/perl-Razor-Agent.spec'], chrootPath='/var/lib/mock/f36-build-31602341-4325681/root'env={'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'}shell=Falselogger=<mockbuild.trace_decorator.getLog object at 0x3ffaaf761f0>timeout=201600uid=1000gid=425user='mockbuild'nspawn_args=[]unshare_net=TrueprintOutput=False)
Executing command: ['bash', '--login', '-c', '/usr/bin/rpmbuild -bb --target s390x --nodeps /builddir/build/SPECS/perl-Razor-Agent.spec'] with env {'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOME': '/builddir', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\\033]0;<mock-chroot>\\007"', 'PS1': '<mock-chroot> \\s-\\v\\$ ', 'LANG': 'C.UTF-8'} and shell False
Building target platforms: s390x
Building for target s390x
setting SOURCE_DATE_EPOCH=1638835200
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.eJgCUo
+ umask 022
+ cd /builddir/build/BUILD
+ cd /builddir/build/BUILD
+ rm -rf Razor2-Client-Agent-2.86
+ /usr/bin/gzip -dc /builddir/build/SOURCES/Razor2-Client-Agent-2.86.tar.gz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd Razor2-Client-Agent-2.86
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.OR8IiJ
+ umask 022
+ cd /builddir/build/BUILD
+ cd Razor2-Client-Agent-2.86
+ perl Makefile.PL INSTALLDIRS=vendor NO_PACKLIST=1 NO_PERLLOCAL=1 'OPTIMIZE=-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection'
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for Razor2::Preproc::deHTMLxs
+ /usr/bin/make -O -j3 V=1 VERBOSE=1
Running Mkbootstrap for deHTMLxs ()
chmod 644 "deHTMLxs.bs"
cp lib/Razor2/String.pm blib/lib/Razor2/String.pm
cp lib/Razor2/Client/Version.pm blib/lib/Razor2/Client/Version.pm
cp lib/Razor2/Preproc/deQP.pm blib/lib/Razor2/Preproc/deQP.pm
cp lib/Razor2/Preproc/Manager.pm blib/lib/Razor2/Preproc/Manager.pm
cp lib/Razor2/Signature/Whiplash.pm blib/lib/Razor2/Signature/Whiplash.pm
cp lib/Razor2/Signature/Ephemeral.pm blib/lib/Razor2/Signature/Ephemeral.pm
cp lib/Razor2/Preproc/deHTML_comment.pm blib/lib/Razor2/Preproc/deHTML_comment.pm
cp lib/Razor2/Logger.pm blib/lib/Razor2/Logger.pm
cp lib/Razor2/Preproc/deBase64.pm blib/lib/Razor2/Preproc/deBase64.pm
cp lib/Razor2/Syslog.pm blib/lib/Razor2/Syslog.pm
AutoSplitting blib/lib/Razor2/Syslog.pm (blib/lib/auto/Razor2/Syslog)
cp lib/Razor2/Preproc/deHTMLxs.pm blib/lib/Razor2/Preproc/deHTMLxs.pm
AutoSplitting blib/lib/Razor2/Preproc/deHTMLxs.pm (blib/lib/auto/Razor2/Preproc/deHTMLxs)
cp lib/Razor2/Client/Core.pm blib/lib/Razor2/Client/Core.pm
cp lib/Razor2/Preproc/enBase64.pm blib/lib/Razor2/Preproc/enBase64.pm
cp lib/Razor2/Preproc/deHTML.pm blib/lib/Razor2/Preproc/deHTML.pm
cp lib/Razor2/Errorhandler.pm blib/lib/Razor2/Errorhandler.pm
cp lib/Razor2/Client/Agent.pm blib/lib/Razor2/Client/Agent.pm
cp lib/Razor2/Engine/VR8.pm blib/lib/Razor2/Engine/VR8.pm
cp lib/Razor2/Preproc/deNewline.pm blib/lib/Razor2/Preproc/deNewline.pm
cp lib/Razor2/Client/Engine.pm blib/lib/Razor2/Client/Engine.pm
cp lib/Razor2/Client/Config.pm blib/lib/Razor2/Client/Config.pm
"/usr/bin/perl" "-MExtUtils::Command::MM" -e pod2man "--" \
docs/razor-agent.conf.pod \
blib/man5/razor-agent.conf.5 \
docs/razor-agents.pod \
blib/man5/razor-agents.5 \
docs/razor-whitelist.pod \
blib/man5/razor-whitelist.5
Manifying 3 pod documents
Can't write-open blib/man5/razor-agent.conf.5: No such file or directory at /usr/share/perl5/vendor_perl/ExtUtils/Command/MM.pm line 153.
make: *** [Makefile:587: manifypods-razor] Error 2
make: *** Waiting for unfinished jobs....
"/usr/bin/perl" "/usr/share/perl5/vendor_perl/ExtUtils/xsubpp"  -typemap '/usr/share/perl5/ExtUtils/typemap' -typemap '/builddir/build/BUILD/Razor2-Client-Agent-2.86/typemap'  deHTMLxs.xs > deHTMLxs.xsc
mv deHTMLxs.xsc deHTMLxs.c
gcc -c   -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection   -DVERSION=\"2.86\" -DXS_VERSION=\"2.86\" -fPIC "-I/usr/lib64/perl5/CORE"   _deHTMLxs.c
error: Bad exit status from /var/tmp/rpm-tmp.OR8IiJ (%build)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.OR8IiJ (%build)
Child return code was: 1
EXCEPTION: [Error()]
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.9/site-packages/mockbuild/util.py", line 600, in do_with_status
    raise exception.Error("Command failed: \n # %s\n%s" % (command, output), child.returncode)
mockbuild.exception.Error: Command failed: 
 # bash --login -c /usr/bin/rpmbuild -bb --target s390x --nodeps /builddir/build/SPECS/perl-Razor-Agent.spec
```