### PR TITLE
Use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,7 +25,7 @@ option, like so:
    following Perl modules from CPAN:
 
             Time::HiRes
-            Digest::SHA1
+            Digest::SHA
             MIME::Base64
             Test::Simple
             Test::Harness

--- a/META.json
+++ b/META.json
@@ -33,7 +33,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Digest::SHA1" : "0",
+            "Digest::SHA" : "0",
             "File::Copy" : "0",
             "File::Spec" : "0",
             "Getopt::Long" : "0",

--- a/META.yml
+++ b/META.yml
@@ -19,7 +19,7 @@ no_index:
     - t
     - inc
 requires:
-  Digest::SHA1: '0'
+  Digest::SHA: '0'
   File::Copy: '0'
   File::Spec: '0'
   Getopt::Long: '0'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
     ( $ExtUtils::MakeMaker::VERSION >= 6.3002 ? ( 'LICENSE' => 'perl', ) : () ),
     EXE_FILES => [qw( bin/razor-client bin/razor-admin bin/razor-check bin/razor-report bin/razor-revoke )],
     PREREQ_PM => {
-        'Digest::SHA1' => 0,
+        'Digest::SHA'  => 0,
         'File::Copy'   => 0,
         'File::Spec'   => 0,
         'Getopt::Long' => 0,

--- a/lib/Razor2/Client/Engine.pm
+++ b/lib/Razor2/Client/Engine.pm
@@ -1,7 +1,6 @@
 package Razor2::Client::Engine;
 
 use strict;
-use Digest::SHA1 qw(sha1_hex);
 use Data::Dumper;
 use Razor2::Signature::Ephemeral;
 use Razor2::Engine::VR8;

--- a/lib/Razor2/Signature/Ephemeral.pm
+++ b/lib/Razor2/Signature/Ephemeral.pm
@@ -2,8 +2,12 @@
 
 package Razor2::Signature::Ephemeral;
 use strict;
-use Digest::SHA1;
 use Data::Dumper;
+
+BEGIN {
+  eval  { require Digest::SHA;  import Digest::SHA  qw(sha1_hex); 1 }
+  or do { require Digest::SHA1; import Digest::SHA1 qw(sha1_hex) }
+}
 
 sub new {
 
@@ -88,17 +92,13 @@ sub hexdigest {
     }
 
     my $digest;
-    my $ctx = Digest::SHA1->new;
 
     if ( $seclength > 128 ) {
-        $ctx->add($section1);
-        $ctx->add($section2);
-        $digest = $ctx->hexdigest;
+        $digest = sha1_hex($section1, $section2);
     }
     else {
         debug("Sections too small... reverting back to orginal content.");
-        $ctx->add($content);
-        $digest = $ctx->hexdigest;
+        $digest = sha1_hex($content);
     }
 
     debug("Computed e-hash is $digest");

--- a/lib/Razor2/Signature/Whiplash.pm
+++ b/lib/Razor2/Signature/Whiplash.pm
@@ -7,7 +7,10 @@
 
 package Razor2::Signature::Whiplash;
 
-use Digest::SHA1;
+BEGIN {
+  eval  { require Digest::SHA;  import Digest::SHA  qw(sha1_hex); 1 }
+  or do { require Digest::SHA1; import Digest::SHA1 qw(sha1_hex) }
+}
 
 sub new {
 
@@ -682,13 +685,8 @@ sub whiplash {
         # the value of length to the nearest multiple of ``length_error''.
         # Take the first 20 hex chars from SHA1 and call it the signature.
 
-        my $sha1 = Digest::SHA1->new();
-
-        $sha1->add($host);
-        $sig = substr $sha1->hexdigest, 0, 12;
-
-        $sha1->add($corrected_length);
-        $sig .= substr $sha1->hexdigest, 0, 4;
+        $sig = substr sha1_hex($host), 0, 12;
+        $sig .= substr sha1_hex($corrected_length), 0, 4;
 
         push @sigs, $sig;
         $sig_meta{$sig} = [ $host, $corrected_length ];

--- a/lib/Razor2/String.pm
+++ b/lib/Razor2/String.pm
@@ -1,10 +1,14 @@
 # $Id: String.pm,v 1.48 2005/06/13 21:09:59 vipul Exp $
 package Razor2::String;
 
-use Digest::SHA1 qw(sha1_hex);
 use URI::Escape;
 use Razor2::Preproc::enBase64;
 use Data::Dumper;
+
+BEGIN {
+  eval  { require Digest::SHA;  import Digest::SHA  qw(sha1_hex); 1 }
+  or do { require Digest::SHA1; import Digest::SHA1 qw(sha1_hex) }
+}
 
 #use MIME::Parser;
 
@@ -65,15 +69,8 @@ sub hmac2_sha1 {
     return unless $text && $iv1 && $iv2;
     die "no ref's allowed" if ref($text);
 
-    my $ctx = Digest::SHA1->new;
-    $ctx->add($iv2);
-    $ctx->add($text);
-    my $digest = $ctx->hexdigest;
-
-    $ctx = Digest::SHA1->new;
-    $ctx->add($iv1);
-    $ctx->add($digest);
-    $digest = $ctx->hexdigest;
+    my $digest = sha1_hex($iv2, $text);
+    $digest = sha1_hex($iv1, $digest);
 
     return ( hextobase64($digest), $digest );
 }


### PR DESCRIPTION
Switch from `Digest::SHA1` to `Digest::SHA`, because: `Digest::SHA` is a bit faster than `Digest::SHA1`, `Digest::SHA1` has been removed from some Linux distributions, `Digest::SHA` is a core library (as of Perl >= 5.10.0) and `Digest::SHA1` is not (and never will be). See also:

 - https://src.fedoraproject.org/rpms/perl-Razor-Agent/c/75fa8a6c1f1fdf779312dac68f331a288bd2920f?branch=rawhide
 - https://stackoverflow.com/questions/3420720/what-are-the-advantages-of-digestsha-over-digestsha1

Original author: Warren Togami (wtogami@redhat.com)